### PR TITLE
Changed zendframework/zend-diactoros to laminas/laminas-diactoros 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "psr/http-message": "^1.0",
     "guzzlehttp/guzzle": "^6.2",
     "league/oauth2-client": "^1.4",
-    "zendframework/zend-diactoros": "^1.7"
+    "laminas/laminas-diactoros": "^2.11"
   },
   "authors": [
     {

--- a/src/Endpoints/AbstractEndpoint.php
+++ b/src/Endpoints/AbstractEndpoint.php
@@ -5,6 +5,7 @@
 
     use GuzzleHttp\Client;
     use GuzzleHttp\Exception\ClientException;
+    use Laminas\Diactoros\Stream;
     use LourensSystems\ApiWrapper\Endpoints\Parameters\GetParameters;
     use LourensSystems\ApiWrapper\Endpoints\Parameters\PdfParameters;
     use LourensSystems\ApiWrapper\Endpoints\Parameters\PreviewParameters;
@@ -20,7 +21,6 @@
     use LourensSystems\ApiWrapper\Endpoints\Parameters\ListParameters;
     use LourensSystems\ApiWrapper\Exception\BadRequestException;
     use LourensSystems\ApiWrapper\Exception\RateLimitException;
-    use Zend\Diactoros\Stream;
     use League\OAuth2\Client\Token\AccessToken;
     use Psr\Http\Message\ResponseInterface;
     use LourensSystems\ApiWrapper\Exception\AuthException;


### PR DESCRIPTION
In order to be able to upgrade to PHP 8 we need to replace the zendframework/zend-diactoros package as it is not maintained anymore and has moved to  laminas/laminas-diactoros  from their information